### PR TITLE
feat: implement user creation and deletion endpoints

### DIFF
--- a/app/Http/Requests/CreateUserRequest.php
+++ b/app/Http/Requests/CreateUserRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateUserRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()->hasPermission('users.create');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'email' => 'required|string|email|max:255|unique:users,email',
+            'password' => 'required|string|min:8|confirmed',
+            'role' => 'nullable|string|in:admin,manager,member',
+        ];
+    }
+
+    /**
+     * Get custom messages for validator errors.
+     */
+    public function messages(): array
+    {
+        return [
+            'name.required' => 'O nome do usuário é obrigatório.',
+            'name.max' => 'O nome não pode ter mais de 255 caracteres.',
+            'email.required' => 'O email é obrigatório.',
+            'email.email' => 'O email deve ter um formato válido.',
+            'email.unique' => 'Este email já está sendo usado por outro usuário.',
+            'email.max' => 'O email não pode ter mais de 255 caracteres.',
+            'password.required' => 'A senha é obrigatória.',
+            'password.min' => 'A senha deve ter pelo menos 8 caracteres.',
+            'password.confirmed' => 'A confirmação da senha não confere.',
+            'role.in' => 'O papel deve ser: admin, manager ou member.',
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,7 @@ return Application::configure(basePath: dirname(__DIR__))
         // Registrar middleware customizado de CSRF
         $middleware->alias([
             'csrf' => \App\Http\Middleware\VerifyCsrfToken::class,
+            'permission' => \App\Http\Middleware\CheckPermission::class,
         ]);
 
         // Para APIs, configuramos o middleware de autenticação

--- a/routes/api.php
+++ b/routes/api.php
@@ -31,6 +31,7 @@ Route::middleware('auth:sanctum')->group(function () {
     // Rotas de usuários
     Route::prefix('users')->group(function () {
         Route::get('/', [UserController::class, 'index']);
+        Route::post('/', [UserController::class, 'store'])->middleware('permission:users.create');
         Route::get('/profile', [UserController::class, 'profile']);
         Route::put('/profile', [UserController::class, 'updateProfile']);
         Route::put('/password', [UserController::class, 'updatePassword']);
@@ -40,6 +41,7 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('/tasks', [UserController::class, 'myTasks']);
         Route::delete('/account', [UserController::class, 'deleteAccount']);
         Route::get('/{user}', [UserController::class, 'show']);
+        Route::delete('/{user}', [UserController::class, 'destroy'])->middleware('permission:users.delete');
 
         // Gerenciamento de roles
         Route::post('/roles/list', [UserController::class, 'getRoles']);
@@ -52,12 +54,17 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('/', [TeamController::class, 'index']);
         Route::post('/', [TeamController::class, 'store']);
         Route::get('/{team}', [TeamController::class, 'show']);
-        Route::put('/{team}', [TeamController::class, 'update']);
-        Route::delete('/{team}', [TeamController::class, 'destroy']);
+        Route::put('/{team}', [TeamController::class, 'update'])->middleware('permission:teams.update');
+        Route::delete('/{team}', [TeamController::class, 'destroy'])->middleware('permission:teams.delete');
 
-        // Gerenciamento de projetos no time
-        Route::post('/{team}/projects', [TeamController::class, 'addProject']);
-        Route::delete('/{team}/projects', [TeamController::class, 'removeProject']);
+        // Gerenciamento de projetos da equipe
+        Route::post('/{team}/projects', [TeamController::class, 'addProject'])->middleware('permission:teams.manage_projects');
+        Route::delete('/{team}/projects/{project}', [TeamController::class, 'removeProject'])->middleware('permission:teams.manage_projects');
+
+        // Gerenciamento de usuários da equipe
+        Route::post('/{team}/users', [TeamController::class, 'store'])->middleware('permission:teams.manage_users');
+        Route::post('/{team}/members', [TeamController::class, 'addMember'])->middleware('permission:teams.manage_users');
+        Route::delete('/{team}/members/{user}', [TeamController::class, 'removeMember'])->middleware('permission:teams.manage_users');
     });
 
     // Rotas de projetos

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1807,6 +1807,246 @@
                 ]
             }
         },
+        "/api/teams/{id}/users": {
+            "post": {
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Criar usuário para equipe",
+                "description": "Cria um novo usuário e o adiciona à equipe (requer permissão users.create)",
+                "operationId": "046f35cb50c11c235d15d96e1ee2e15f",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID da equipe",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "João Silva"
+                                    },
+                                    "email": {
+                                        "type": "string",
+                                        "format": "email",
+                                        "example": "joao@exemplo.com"
+                                    },
+                                    "password": {
+                                        "type": "string",
+                                        "example": "senha123"
+                                    },
+                                    "password_confirmation": {
+                                        "type": "string",
+                                        "example": "senha123"
+                                    },
+                                    "role": {
+                                        "description": "Papel a ser atribuído (admin, manager, member)",
+                                        "type": "string",
+                                        "example": "member",
+                                        "nullable": true
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Usuário criado com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ApiResponse"
+                                        },
+                                        {
+                                            "properties": {
+                                                "data": {
+                                                    "properties": {
+                                                        "id": {
+                                                            "type": "integer"
+                                                        },
+                                                        "name": {
+                                                            "type": "string"
+                                                        },
+                                                        "email": {
+                                                            "type": "string"
+                                                        },
+                                                        "created_at": {
+                                                            "type": "string",
+                                                            "format": "date-time"
+                                                        },
+                                                        "roles": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "object"
+                                                            }
+                                                        }
+                                                    },
+                                                    "type": "object"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Acesso negado - sem permissão ou não é dono da equipe"
+                    },
+                    "422": {
+                        "description": "Dados de validação inválidos"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/teams/{id}/members": {
+            "post": {
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Adicionar membro à equipe",
+                "description": "Adiciona um usuário existente como membro da equipe (requer ser dono da equipe ou permissão teams.manage_members)",
+                "operationId": "f6c5f3d3cadae81f5d969f2385fabb30",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID da equipe",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "user_id": {
+                                        "description": "ID do usuário a ser adicionado",
+                                        "type": "integer",
+                                        "example": 1
+                                    },
+                                    "role": {
+                                        "description": "Role do usuário na equipe (opcional)",
+                                        "type": "string",
+                                        "example": "member"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Membro adicionado com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Sem permissão para gerenciar membros da equipe"
+                    },
+                    "404": {
+                        "description": "Usuário não encontrado"
+                    },
+                    "409": {
+                        "description": "Usuário já é membro da equipe"
+                    },
+                    "422": {
+                        "description": "Dados de validação inválidos"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/teams/{id}/members/{user}": {
+            "delete": {
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Remover membro da equipe",
+                "description": "Remove um usuário da equipe (requer ser dono da equipe ou permissão teams.manage_members)",
+                "operationId": "9c017613f78718759a722b9996fd1470",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "ID da equipe",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "ID do usuário a ser removido",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Membro removido com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Sem permissão para gerenciar membros da equipe"
+                    },
+                    "404": {
+                        "description": "Usuário não é membro da equipe"
+                    },
+                    "422": {
+                        "description": "Não é possível remover o dono da equipe"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
         "/api/users": {
             "get": {
                 "tags": [
@@ -1871,6 +2111,87 @@
                     },
                     "401": {
                         "description": "Não autenticado"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            },
+            "post": {
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Criar usuário",
+                "description": "Cria um novo usuário no sistema (requer permissão users.create)",
+                "operationId": "be551c1d694a01c164966f58bfa77013",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "name": {
+                                        "description": "Nome do usuário",
+                                        "type": "string",
+                                        "example": "João Silva"
+                                    },
+                                    "email": {
+                                        "description": "Email do usuário",
+                                        "type": "string",
+                                        "format": "email",
+                                        "example": "joao@exemplo.com"
+                                    },
+                                    "password": {
+                                        "description": "Senha do usuário",
+                                        "type": "string",
+                                        "example": "senha123"
+                                    },
+                                    "password_confirmation": {
+                                        "description": "Confirmação da senha",
+                                        "type": "string",
+                                        "example": "senha123"
+                                    },
+                                    "role": {
+                                        "description": "Role inicial do usuário (opcional)",
+                                        "type": "string",
+                                        "example": "member"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Usuário criado com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ApiResponse"
+                                        },
+                                        {
+                                            "properties": {
+                                                "data": {
+                                                    "$ref": "#/components/schemas/User"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Sem permissão para criar usuários"
+                    },
+                    "422": {
+                        "description": "Dados de validação inválidos"
                     }
                 },
                 "security": [
@@ -2123,6 +2444,53 @@
                     },
                     "404": {
                         "description": "Usuário não encontrado"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/users/{user}": {
+            "delete": {
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Excluir usuário",
+                "description": "Remove um usuário do sistema (requer permissão users.delete)",
+                "operationId": "cf641f0b739211ff3a1c21b1ef310591",
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "ID do usuário",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Usuário excluído com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiResponse"
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "Sem permissão para excluir usuários"
+                    },
+                    "404": {
+                        "description": "Usuário não encontrado"
+                    },
+                    "422": {
+                        "description": "Não é possível excluir usuário com dados associados"
                     }
                 },
                 "security": [


### PR DESCRIPTION
- Add POST /api/users endpoint with validation and permission checks
- Add DELETE /api/users/{user} endpoint with security validations
- Implement CreateUserRequest for input validation
- Add comprehensive tests for both endpoints
- Update Swagger documentation with new endpoints
- Fix permission check order in user deletion
- Add success messages to user show endpoint for consistency