### PR TITLE
feat: separate avatar upload from profile update endpoint

### DIFF
--- a/app/Http/Controllers/Api/Schemas.php
+++ b/app/Http/Controllers/Api/Schemas.php
@@ -12,6 +12,10 @@ namespace App\Http\Controllers\Api;
  *     @OA\Property(property="name", type="string", example="João Silva"),
  *     @OA\Property(property="email", type="string", format="email", example="joao@exemplo.com"),
  *     @OA\Property(property="email_verified_at", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="avatar", type="string", nullable=true, example="https://example.com/avatar.jpg"),
+ *     @OA\Property(property="phone", type="string", nullable=true, example="+55 11 99999-9999"),
+ *     @OA\Property(property="position", type="string", nullable=true, example="Desenvolvedor Full Stack"),
+ *     @OA\Property(property="description", type="string", nullable=true, example="Desenvolvedor experiente com foco em Laravel e Vue.js"),
  *     @OA\Property(property="created_at", type="string", format="date-time"),
  *     @OA\Property(property="updated_at", type="string", format="date-time")
  * )

--- a/app/Http/Controllers/Api/UserController.php
+++ b/app/Http/Controllers/Api/UserController.php
@@ -103,14 +103,17 @@ class UserController extends Controller
      *     path="/api/user/profile",
      *     tags={"Users"},
      *     summary="Atualizar perfil do usuário",
-     *     description="Atualiza as informações do perfil do usuário autenticado",
+     *     description="Atualiza as informações do perfil do usuário autenticado (exceto avatar)",
      *     security={{"sanctum": {}}},
      *     @OA\RequestBody(
      *         required=true,
      *         @OA\JsonContent(
      *             type="object",
      *             @OA\Property(property="name", type="string", maxLength=255, example="João Silva"),
-     *             @OA\Property(property="email", type="string", format="email", example="joao@exemplo.com")
+     *             @OA\Property(property="email", type="string", format="email", example="joao@exemplo.com"),
+     *             @OA\Property(property="phone", type="string", maxLength=20, example="+55 11 99999-9999"),
+     *             @OA\Property(property="position", type="string", maxLength=255, example="Desenvolvedor Full Stack"),
+     *             @OA\Property(property="description", type="string", maxLength=1000, example="Desenvolvedor experiente com foco em Laravel e Vue.js")
      *         )
      *     ),
      *     @OA\Response(
@@ -144,6 +147,9 @@ class UserController extends Controller
             $validated = $request->validate([
                 'name' => 'sometimes|required|string|max:255',
                 'email' => 'sometimes|required|email|unique:users,email,' . Auth::id(),
+                'phone' => 'sometimes|nullable|string|max:20',
+                'position' => 'sometimes|nullable|string|max:255',
+                'description' => 'sometimes|nullable|string|max:1000',
             ]);
 
             $user = Auth::user();
@@ -219,6 +225,83 @@ class UserController extends Controller
             ]);
 
             return $this->successResponse(null, 'Senha atualizada com sucesso');
+        } catch (ValidationException $e) {
+            return $this->validationErrorResponse($e->errors());
+        }
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/users/avatar",
+     *     tags={"Users"},
+     *     summary="Atualizar avatar do usuário",
+     *     description="Faz upload e atualiza o avatar do usuário autenticado",
+     *     security={{"sanctum": {}}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\MediaType(
+     *             mediaType="multipart/form-data",
+     *             @OA\Schema(
+     *                 type="object",
+     *                 required={"avatar"},
+     *                 @OA\Property(
+     *                     property="avatar",
+     *                     type="string",
+     *                     format="binary",
+     *                     description="Arquivo de imagem do avatar (JPG, PNG, GIF, máximo 2MB)"
+     *                 )
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Avatar atualizado com sucesso",
+     *         @OA\JsonContent(
+     *             allOf={
+     *                 @OA\Schema(ref="#/components/schemas/ApiResponse"),
+     *                 @OA\Schema(
+     *                     @OA\Property(property="data", ref="#/components/schemas/User")
+     *                 )
+     *             }
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Não autenticado"
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         description="Dados inválidos",
+     *         @OA\JsonContent(ref="#/components/schemas/ValidationError")
+     *     )
+     * )
+     * 
+     * Faz upload e atualiza o avatar do usuário
+     */
+    public function updateAvatar(Request $request): JsonResponse
+    {
+        try {
+            $validated = $request->validate([
+                'avatar' => 'required|image|mimes:jpeg,png,jpg,gif|max:2048',
+            ]);
+
+            $user = Auth::user();
+            
+            // Remove o avatar anterior se existir
+            if ($user->avatar && \Storage::disk('public')->exists($user->avatar)) {
+                \Storage::disk('public')->delete($user->avatar);
+            }
+
+            // Faz upload do novo avatar
+            $avatarPath = $request->file('avatar')->store('avatars', 'public');
+            
+            // Atualiza o usuário com o caminho do novo avatar
+            $user->update(['avatar' => $avatarPath]);
+
+            // Limpar cache do usuário após atualização
+            $this->clearUserCache($user->id);
+
+            return $this->successResponse($user, 'Avatar atualizado com sucesso');
         } catch (ValidationException $e) {
             return $this->validationErrorResponse($e->errors());
         }
@@ -496,25 +579,31 @@ class UserController extends Controller
 
     /**
      * @OA\Get(
-     *     path="/api/user/projects",
-     *     tags={"Users"},
-     *     summary="Meus projetos",
-     *     description="Lista todos os projetos do usuário autenticado",
-     *     security={{"sanctum": {}}},
+     *     path="/api/my/projects",
+     *     tags={"User"},
+     *     summary="Listar projetos do usuário",
+     *     description="Lista todos os projetos que o usuário possui ou é membro",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="status",
+     *         in="query",
+     *         description="Filtrar por status do projeto",
+     *         required=false,
+     *         @OA\Schema(
+     *             type="string",
+     *             enum={"planning", "active", "on_hold", "completed", "cancelled"}
+     *         )
+     *     ),
      *     @OA\Response(
      *         response=200,
      *         description="Lista de projetos do usuário",
      *         @OA\JsonContent(
-     *             allOf={
-     *                 @OA\Schema(ref="#/components/schemas/ApiResponse"),
-     *                 @OA\Schema(
-     *                     @OA\Property(
-     *                         property="data",
-     *                         type="array",
-     *                         @OA\Items(ref="#/components/schemas/Project")
-     *                     )
-     *                 )
-     *             }
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/Project")
+     *             )
      *         )
      *     ),
      *     @OA\Response(
@@ -525,36 +614,63 @@ class UserController extends Controller
      * 
      * Lista projetos do usuário
      */
-    public function myProjects(): JsonResponse
+    public function myProjects(Request $request): JsonResponse
     {
-        $projects = Auth::user()->ownedProjects()
-            ->with(['teams', 'tasks'])
-            ->get();
-
-        return $this->successResponse($projects);
+        $user = Auth::user();
+        
+        // Buscar projetos próprios (onde o usuário é owner)
+        $ownedProjects = $user->ownedProjects()
+            ->with(['teams', 'tasks', 'owner']);
+            
+        // Buscar projetos onde o usuário é membro
+        $memberProjects = $user->projects()
+            ->with(['teams', 'tasks', 'owner']);
+        
+        // Aplicar filtros se fornecidos
+        if ($request->has('status')) {
+            $ownedProjects->where('status', $request->status);
+            $memberProjects->where('status', $request->status);
+        }
+        
+        // Combinar as duas consultas e remover duplicatas
+        $ownedProjectsCollection = $ownedProjects->get();
+        $memberProjectsCollection = $memberProjects->get();
+        
+        // Mesclar e remover duplicatas baseado no ID
+        $allProjects = $ownedProjectsCollection->merge($memberProjectsCollection)->unique('id');
+        
+        // Ordenar por data de criação (mais recentes primeiro)
+        $allProjects = $allProjects->sortByDesc('created_at')->values();
+        
+        return $this->successResponse($allProjects);
     }
 
     /**
      * @OA\Get(
-     *     path="/api/user/teams",
-     *     tags={"Users"},
-     *     summary="Meus times",
-     *     description="Lista todos os times do usuário autenticado",
-     *     security={{"sanctum": {}}},
+     *     path="/api/my/teams",
+     *     tags={"User"},
+     *     summary="Listar equipes do usuário",
+     *     description="Lista todas as equipes que o usuário possui ou é membro",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="is_active",
+     *         in="query",
+     *         description="Filtrar por status da equipe",
+     *         required=false,
+     *         @OA\Schema(
+     *             type="boolean"
+     *         )
+     *     ),
      *     @OA\Response(
      *         response=200,
-     *         description="Lista de times do usuário",
+     *         description="Lista de equipes do usuário",
      *         @OA\JsonContent(
-     *             allOf={
-     *                 @OA\Schema(ref="#/components/schemas/ApiResponse"),
-     *                 @OA\Schema(
-     *                     @OA\Property(
-     *                         property="data",
-     *                         type="array",
-     *                         @OA\Items(ref="#/components/schemas/Team")
-     *                     )
-     *                 )
-     *             }
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/Team")
+     *             )
      *         )
      *     ),
      *     @OA\Response(
@@ -565,13 +681,363 @@ class UserController extends Controller
      * 
      * Lista times do usuário
      */
-    public function myTeams(): JsonResponse
+    public function myTeams(Request $request): JsonResponse
     {
-        $teams = Auth::user()->ownedTeams()
-            ->with(['projects', 'owner'])
-            ->get();
+        $user = Auth::user();
+        
+        // Buscar equipes próprias (onde o usuário é owner)
+        $ownedTeams = $user->ownedTeams()
+            ->with(['projects', 'owner']);
+            
+        // Buscar equipes onde o usuário é membro
+        $memberTeams = $user->teams()
+            ->with(['projects', 'owner']);
+        
+        // Aplicar filtros se fornecidos
+        if ($request->has('is_active')) {
+            $isActive = filter_var($request->is_active, FILTER_VALIDATE_BOOLEAN);
+            $ownedTeams->where('is_active', $isActive);
+            $memberTeams->where('is_active', $isActive);
+        }
+        
+        // Combinar as duas consultas e remover duplicatas
+        $ownedTeamsCollection = $ownedTeams->get();
+        $memberTeamsCollection = $memberTeams->get();
+        
+        // Mesclar e remover duplicatas baseado no ID
+        $allTeams = $ownedTeamsCollection->merge($memberTeamsCollection)->unique('id');
+        
+        // Ordenar por data de criação (mais recentes primeiro)
+        $allTeams = $allTeams->sortByDesc('created_at')->values();
+        
+        return $this->successResponse($allTeams);
+    }
 
-        return $this->successResponse($teams);
+    /**
+     * @OA\Get(
+     *     path="/api/my/tasks",
+     *     tags={"User"},
+     *     summary="Listar tarefas do usuário",
+     *     description="Lista todas as tarefas criadas pelo usuário ou atribuídas a ele",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="status",
+     *         in="query",
+     *         description="Filtrar por status da tarefa",
+     *         required=false,
+     *         @OA\Schema(
+     *             type="string",
+     *             enum={"todo", "in_progress", "review", "done", "cancelled"}
+     *         )
+     *     ),
+     *     @OA\Parameter(
+     *         name="priority",
+     *         in="query",
+     *         description="Filtrar por prioridade da tarefa",
+     *         required=false,
+     *         @OA\Schema(
+     *             type="string",
+     *             enum={"low", "medium", "high", "urgent"}
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Lista de tarefas do usuário",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/Task")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Não autenticado"
+     *     )
+     * )
+     * 
+     * Lista tarefas do usuário
+     */
+    public function myTasks(Request $request): JsonResponse
+    {
+        $user = Auth::user();
+        
+        // Buscar tarefas criadas pelo usuário
+        $createdTasks = $user->createdTasks()
+            ->with(['project', 'creator', 'users']);
+            
+        // Buscar tarefas atribuídas ao usuário
+        $assignedTasks = $user->tasks()
+            ->with(['project', 'creator', 'users']);
+        
+        // Aplicar filtros se fornecidos
+        if ($request->has('status')) {
+            $createdTasks->where('status', $request->status);
+            $assignedTasks->where('status', $request->status);
+        }
+        
+        if ($request->has('priority')) {
+            $createdTasks->where('priority', $request->priority);
+            $assignedTasks->where('priority', $request->priority);
+        }
+        
+        // Combinar as duas consultas e remover duplicatas
+        $createdTasksCollection = $createdTasks->get();
+        $assignedTasksCollection = $assignedTasks->get();
+        
+        // Mesclar e remover duplicatas baseado no ID
+        $allTasks = $createdTasksCollection->merge($assignedTasksCollection)->unique('id');
+        
+        // Ordenar por data de criação (mais recentes primeiro)
+        $allTasks = $allTasks->sortByDesc('created_at')->values();
+        
+        return $this->successResponse($allTasks);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/users/{user}/tasks",
+     *     tags={"Users"},
+     *     summary="Listar tarefas de um usuário específico",
+     *     description="Lista todas as tarefas criadas por ou atribuídas a um usuário específico",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="user",
+     *         in="path",
+     *         description="ID do usuário",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="status",
+     *         in="query",
+     *         description="Filtrar por status da tarefa",
+     *         required=false,
+     *         @OA\Schema(
+     *             type="string",
+     *             enum={"todo", "in_progress", "review", "done", "cancelled"}
+     *         )
+     *     ),
+     *     @OA\Parameter(
+     *         name="priority",
+     *         in="query",
+     *         description="Filtrar por prioridade da tarefa",
+     *         required=false,
+     *         @OA\Schema(
+     *             type="string",
+     *             enum={"low", "medium", "high", "urgent"}
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Lista de tarefas do usuário",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/Task")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Não autenticado"
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Usuário não encontrado"
+     *     )
+     * )
+     * 
+     * Lista tarefas de um usuário específico
+     */
+    public function getUserTasks(Request $request, User $user): JsonResponse
+    {
+        // Buscar tarefas criadas pelo usuário
+        $createdTasks = $user->createdTasks()
+            ->with(['project', 'creator', 'users']);
+            
+        // Buscar tarefas atribuídas ao usuário
+        $assignedTasks = $user->tasks()
+            ->with(['project', 'creator', 'users']);
+        
+        // Aplicar filtros se fornecidos
+        if ($request->has('status')) {
+            $createdTasks->where('status', $request->status);
+            $assignedTasks->where('status', $request->status);
+        }
+        
+        if ($request->has('priority')) {
+            $createdTasks->where('priority', $request->priority);
+            $assignedTasks->where('priority', $request->priority);
+        }
+        
+        // Combinar as duas consultas e remover duplicatas
+        $createdTasksCollection = $createdTasks->get();
+        $assignedTasksCollection = $assignedTasks->get();
+        
+        // Mesclar e remover duplicatas baseado no ID
+        $allTasks = $createdTasksCollection->merge($assignedTasksCollection)->unique('id');
+        
+        // Ordenar por data de criação (mais recentes primeiro)
+        $allTasks = $allTasks->sortByDesc('created_at')->values();
+        
+        return $this->successResponse($allTasks);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/users/{user}/projects",
+     *     tags={"Users"},
+     *     summary="Listar projetos de um usuário específico",
+     *     description="Lista todos os projetos que um usuário específico possui ou é membro",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="user",
+     *         in="path",
+     *         description="ID do usuário",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="status",
+     *         in="query",
+     *         description="Filtrar por status do projeto",
+     *         required=false,
+     *         @OA\Schema(
+     *             type="string",
+     *             enum={"planning", "active", "on_hold", "completed", "cancelled"}
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Lista de projetos do usuário",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/Project")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Não autenticado"
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Usuário não encontrado"
+     *     )
+     * )
+     * 
+     * Lista projetos de um usuário específico
+     */
+    public function getUserProjects(Request $request, User $user): JsonResponse
+    {
+        // Buscar projetos próprios (onde o usuário é owner)
+        $ownedProjects = $user->ownedProjects()
+            ->with(['teams', 'tasks', 'owner']);
+            
+        // Buscar projetos onde o usuário é membro
+        $memberProjects = $user->projects()
+            ->with(['teams', 'tasks', 'owner']);
+        
+        // Aplicar filtros se fornecidos
+        if ($request->has('status')) {
+            $ownedProjects->where('status', $request->status);
+            $memberProjects->where('status', $request->status);
+        }
+        
+        // Combinar as duas consultas e remover duplicatas
+        $ownedProjectsCollection = $ownedProjects->get();
+        $memberProjectsCollection = $memberProjects->get();
+        
+        // Mesclar e remover duplicatas baseado no ID
+        $allProjects = $ownedProjectsCollection->merge($memberProjectsCollection)->unique('id');
+        
+        // Ordenar por data de criação (mais recentes primeiro)
+        $allProjects = $allProjects->sortByDesc('created_at')->values();
+        
+        return $this->successResponse($allProjects);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/users/{user}/teams",
+     *     tags={"Users"},
+     *     summary="Listar equipes de um usuário específico",
+     *     description="Lista todas as equipes que um usuário específico possui ou é membro",
+     *     security={{"bearerAuth":{}}},
+     *     @OA\Parameter(
+     *         name="user",
+     *         in="path",
+     *         description="ID do usuário",
+     *         required=true,
+     *         @OA\Schema(type="integer")
+     *     ),
+     *     @OA\Parameter(
+     *         name="is_active",
+     *         in="query",
+     *         description="Filtrar por status da equipe",
+     *         required=false,
+     *         @OA\Schema(type="boolean")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Lista de equipes do usuário",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="success", type="boolean", example=true),
+     *             @OA\Property(
+     *                 property="data",
+     *                 type="array",
+     *                 @OA\Items(ref="#/components/schemas/Team")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Não autenticado"
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Usuário não encontrado"
+     *     )
+     * )
+     * 
+     * Lista equipes de um usuário específico
+     */
+    public function getUserTeams(Request $request, User $user): JsonResponse
+    {
+        // Buscar equipes próprias (onde o usuário é owner)
+        $ownedTeams = $user->ownedTeams()
+            ->with(['projects', 'owner']);
+            
+        // Buscar equipes onde o usuário é membro
+        $memberTeams = $user->teams()
+            ->with(['projects', 'owner']);
+        
+        // Aplicar filtros se fornecidos
+        if ($request->has('is_active')) {
+            $isActive = filter_var($request->is_active, FILTER_VALIDATE_BOOLEAN);
+            $ownedTeams->where('is_active', $isActive);
+            $memberTeams->where('is_active', $isActive);
+        }
+        
+        // Combinar as duas consultas e remover duplicatas
+        $ownedTeamsCollection = $ownedTeams->get();
+        $memberTeamsCollection = $memberTeams->get();
+        
+        // Mesclar e remover duplicatas baseado no ID
+        $allTeams = $ownedTeamsCollection->merge($memberTeamsCollection)->unique('id');
+        
+        // Ordenar por data de criação (mais recentes primeiro)
+        $allTeams = $allTeams->sortByDesc('created_at')->values();
+        
+        return $this->successResponse($allTeams);
     }
 
 

--- a/app/Models/Project.php
+++ b/app/Models/Project.php
@@ -44,6 +44,11 @@ class Project extends Model
         return $this->hasMany(Task::class);
     }
 
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'project_user')->withTimestamps();
+    }
+
     /**
      * Scopes
      */

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -35,6 +35,11 @@ class Team extends Model
         return $this->belongsToMany(Project::class);
     }
 
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class, 'team_user')->withTimestamps();
+    }
+
     /**
      * Scopes
      */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,6 +24,10 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'avatar',
+        'phone',
+        'position',
+        'description',
     ];
 
     /**

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -29,6 +29,10 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'avatar' => fake()->imageUrl(200, 200, 'people'),
+            'phone' => fake()->phoneNumber(),
+            'position' => fake()->jobTitle(),
+            'description' => fake()->paragraph(3),
         ];
     }
 

--- a/database/migrations/2025_10_08_212657_add_profile_fields_to_users_table.php
+++ b/database/migrations/2025_10_08_212657_add_profile_fields_to_users_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('avatar')->nullable()->after('email');
+            $table->string('phone', 20)->nullable()->after('avatar');
+            $table->string('position')->nullable()->after('phone');
+            $table->text('description')->nullable()->after('position');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['avatar', 'phone', 'position', 'description']);
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,12 +28,20 @@ Route::middleware('auth:sanctum')->group(function () {
     // Rota para listar todas as roles
     Route::get('/roles', [UserController::class, 'listRoles']);
 
+    // Rotas de recursos do usuário autenticado
+    Route::prefix('my')->group(function () {
+        Route::get('/tasks', [UserController::class, 'myTasks']);
+        Route::get('/projects', [UserController::class, 'myProjects']);
+        Route::get('/teams', [UserController::class, 'myTeams']);
+    });
+
     // Rotas de usuários
     Route::prefix('users')->group(function () {
         Route::get('/', [UserController::class, 'index']);
         Route::post('/', [UserController::class, 'store'])->middleware('permission:users.create');
         Route::get('/profile', [UserController::class, 'profile']);
         Route::put('/profile', [UserController::class, 'updateProfile']);
+        Route::post('/avatar', [UserController::class, 'updateAvatar']);
         Route::put('/password', [UserController::class, 'updatePassword']);
         Route::get('/dashboard', [UserController::class, 'dashboard']);
         Route::get('/projects', [UserController::class, 'myProjects']);
@@ -41,6 +49,9 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::get('/tasks', [UserController::class, 'myTasks']);
         Route::delete('/account', [UserController::class, 'deleteAccount']);
         Route::get('/{user}', [UserController::class, 'show']);
+        Route::get('/{user}/tasks', [UserController::class, 'getUserTasks']);
+        Route::get('/{user}/projects', [UserController::class, 'getUserProjects']);
+        Route::get('/{user}/teams', [UserController::class, 'getUserTeams']);
         Route::delete('/{user}', [UserController::class, 'destroy'])->middleware('permission:users.delete');
 
         // Gerenciamento de roles

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -2247,7 +2247,7 @@
                     "Users"
                 ],
                 "summary": "Atualizar perfil do usuário",
-                "description": "Atualiza as informações do perfil do usuário autenticado",
+                "description": "Atualiza as informações do perfil do usuário autenticado (exceto avatar)",
                 "operationId": "f5dfce3753e793253c65d12b593248a3",
                 "requestBody": {
                     "required": true,
@@ -2264,6 +2264,21 @@
                                         "type": "string",
                                         "format": "email",
                                         "example": "joao@exemplo.com"
+                                    },
+                                    "phone": {
+                                        "type": "string",
+                                        "maxLength": 20,
+                                        "example": "+55 11 99999-9999"
+                                    },
+                                    "position": {
+                                        "type": "string",
+                                        "maxLength": 255,
+                                        "example": "Desenvolvedor Full Stack"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "maxLength": 1000,
+                                        "example": "Desenvolvedor experiente com foco em Laravel e Vue.js"
                                     }
                                 },
                                 "type": "object"
@@ -2384,6 +2399,78 @@
                     },
                     "422": {
                         "description": "Dados inválidos ou senha atual incorreta",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ValidationError"
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/users/avatar": {
+            "post": {
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Atualizar avatar do usuário",
+                "description": "Faz upload e atualiza o avatar do usuário autenticado",
+                "operationId": "46c4aaa9af5e7cebc37c5adfeb202d30",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "multipart/form-data": {
+                            "schema": {
+                                "required": [
+                                    "avatar"
+                                ],
+                                "properties": {
+                                    "avatar": {
+                                        "description": "Arquivo de imagem do avatar (JPG, PNG, GIF, máximo 2MB)",
+                                        "type": "string",
+                                        "format": "binary"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Avatar atualizado com sucesso",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "allOf": [
+                                        {
+                                            "$ref": "#/components/schemas/ApiResponse"
+                                        },
+                                        {
+                                            "properties": {
+                                                "data": {
+                                                    "$ref": "#/components/schemas/User"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado"
+                    },
+                    "422": {
+                        "description": "Dados inválidos",
                         "content": {
                             "application/json": {
                                 "schema": {
@@ -2574,36 +2661,51 @@
                 ]
             }
         },
-        "/api/user/projects": {
+        "/api/my/projects": {
             "get": {
                 "tags": [
-                    "Users"
+                    "User"
                 ],
-                "summary": "Meus projetos",
-                "description": "Lista todos os projetos do usuário autenticado",
-                "operationId": "9a74a5f740bcaad430f7c1f93d1fa06c",
+                "summary": "Listar projetos do usuário",
+                "description": "Lista todos os projetos que o usuário possui ou é membro",
+                "operationId": "b30e6338035de2cdc090f69f55701159",
+                "parameters": [
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filtrar por status do projeto",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "planning",
+                                "active",
+                                "on_hold",
+                                "completed",
+                                "cancelled"
+                            ]
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
                         "description": "Lista de projetos do usuário",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/components/schemas/ApiResponse"
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
                                         },
-                                        {
-                                            "properties": {
-                                                "data": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/Project"
-                                                    }
-                                                }
-                                            },
-                                            "type": "object"
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Project"
+                                            }
                                         }
-                                    ]
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -2614,41 +2716,49 @@
                 },
                 "security": [
                     {
-                        "sanctum": []
+                        "bearerAuth": []
                     }
                 ]
             }
         },
-        "/api/user/teams": {
+        "/api/my/teams": {
             "get": {
                 "tags": [
-                    "Users"
+                    "User"
                 ],
-                "summary": "Meus times",
-                "description": "Lista todos os times do usuário autenticado",
-                "operationId": "ff626a465557a3a8c9ba1353019603ed",
+                "summary": "Listar equipes do usuário",
+                "description": "Lista todas as equipes que o usuário possui ou é membro",
+                "operationId": "6c1937de9bb936510da8396562388e53",
+                "parameters": [
+                    {
+                        "name": "is_active",
+                        "in": "query",
+                        "description": "Filtrar por status da equipe",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
                 "responses": {
                     "200": {
-                        "description": "Lista de times do usuário",
+                        "description": "Lista de equipes do usuário",
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "allOf": [
-                                        {
-                                            "$ref": "#/components/schemas/ApiResponse"
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
                                         },
-                                        {
-                                            "properties": {
-                                                "data": {
-                                                    "type": "array",
-                                                    "items": {
-                                                        "$ref": "#/components/schemas/Team"
-                                                    }
-                                                }
-                                            },
-                                            "type": "object"
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Team"
+                                            }
                                         }
-                                    ]
+                                    },
+                                    "type": "object"
                                 }
                             }
                         }
@@ -2659,7 +2769,306 @@
                 },
                 "security": [
                     {
-                        "sanctum": []
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/my/tasks": {
+            "get": {
+                "tags": [
+                    "User"
+                ],
+                "summary": "Listar tarefas do usuário",
+                "description": "Lista todas as tarefas criadas pelo usuário ou atribuídas a ele",
+                "operationId": "28099422b3dd49e97ddf5cae781d588b",
+                "parameters": [
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filtrar por status da tarefa",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "todo",
+                                "in_progress",
+                                "review",
+                                "done",
+                                "cancelled"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "priority",
+                        "in": "query",
+                        "description": "Filtrar por prioridade da tarefa",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "low",
+                                "medium",
+                                "high",
+                                "urgent"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lista de tarefas do usuário",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Task"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/users/{user}/tasks": {
+            "get": {
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Listar tarefas de um usuário específico",
+                "description": "Lista todas as tarefas criadas por ou atribuídas a um usuário específico",
+                "operationId": "b792205b0a5627cbbe6956afe0e1473f",
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "ID do usuário",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filtrar por status da tarefa",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "todo",
+                                "in_progress",
+                                "review",
+                                "done",
+                                "cancelled"
+                            ]
+                        }
+                    },
+                    {
+                        "name": "priority",
+                        "in": "query",
+                        "description": "Filtrar por prioridade da tarefa",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "low",
+                                "medium",
+                                "high",
+                                "urgent"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lista de tarefas do usuário",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Task"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado"
+                    },
+                    "404": {
+                        "description": "Usuário não encontrado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/users/{user}/projects": {
+            "get": {
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Listar projetos de um usuário específico",
+                "description": "Lista todos os projetos que um usuário específico possui ou é membro",
+                "operationId": "5150d68bed47b1927b9dc4d12e279b48",
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "ID do usuário",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "status",
+                        "in": "query",
+                        "description": "Filtrar por status do projeto",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "planning",
+                                "active",
+                                "on_hold",
+                                "completed",
+                                "cancelled"
+                            ]
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lista de projetos do usuário",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Project"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado"
+                    },
+                    "404": {
+                        "description": "Usuário não encontrado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
+                    }
+                ]
+            }
+        },
+        "/api/users/{user}/teams": {
+            "get": {
+                "tags": [
+                    "Users"
+                ],
+                "summary": "Listar equipes de um usuário específico",
+                "description": "Lista todas as equipes que um usuário específico possui ou é membro",
+                "operationId": "ac8cecf1821aca2e3c4e62a57fa16ae3",
+                "parameters": [
+                    {
+                        "name": "user",
+                        "in": "path",
+                        "description": "ID do usuário",
+                        "required": true,
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "is_active",
+                        "in": "query",
+                        "description": "Filtrar por status da equipe",
+                        "required": false,
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Lista de equipes do usuário",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "success": {
+                                            "type": "boolean",
+                                            "example": true
+                                        },
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/components/schemas/Team"
+                                            }
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Não autenticado"
+                    },
+                    "404": {
+                        "description": "Usuário não encontrado"
+                    }
+                },
+                "security": [
+                    {
+                        "bearerAuth": []
                     }
                 ]
             }
@@ -2687,6 +3096,26 @@
                     "email_verified_at": {
                         "type": "string",
                         "format": "date-time",
+                        "nullable": true
+                    },
+                    "avatar": {
+                        "type": "string",
+                        "example": "https://example.com/avatar.jpg",
+                        "nullable": true
+                    },
+                    "phone": {
+                        "type": "string",
+                        "example": "+55 11 99999-9999",
+                        "nullable": true
+                    },
+                    "position": {
+                        "type": "string",
+                        "example": "Desenvolvedor Full Stack",
+                        "nullable": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "example": "Desenvolvedor experiente com foco em Laravel e Vue.js",
                         "nullable": true
                     },
                     "created_at": {
@@ -2953,6 +3382,10 @@
         {
             "name": "Teams",
             "description": "Gerenciamento de equipes"
+        },
+        {
+            "name": "User",
+            "description": "User"
         }
     ]
 }


### PR DESCRIPTION
- Remove avatar field from profile update endpoint (PUT /api/users/profile)
- Create dedicated avatar upload endpoint (POST /api/users/avatar)
- Change avatar endpoint to accept file uploads instead of URLs
- Add file validation (image types: jpeg,png,jpg,gif, max size: 2MB)
- Implement automatic old file removal when updating avatar
- Update Swagger documentation for both endpoints
- Add comprehensive tests for file upload functionality
- Update existing profile tests to exclude avatar field

Breaking Changes:
- Avatar field no longer accepted in profile update endpoint
- Avatar endpoint changed from PUT to POST with multipart/form-data